### PR TITLE
Use the correct public header (#8)

### DIFF
--- a/sqlite3.podspec
+++ b/sqlite3.podspec
@@ -21,6 +21,7 @@ LICENSE
 
   s.subspec 'common' do |ss|
     ss.source_files = "#{archive_name}/sqlite*.{h,c}"
+    ss.public_header_files = "#{archive_name}/sqlite3.h"
     ss.osx.pod_target_xcconfig = { 'OTHER_CFLAGS' => '$(inherited) -DHAVE_USLEEP=1' }
     # Disable OS X / AFP locking code on mobile platforms (iOS, tvOS, watchOS)
     sqlite_xcconfig_ios = { 'OTHER_CFLAGS' => '$(inherited) -DHAVE_USLEEP=1 -DSQLITE_ENABLE_LOCKING_STYLE=0' }


### PR DESCRIPTION
This seems to work as expected.

```objc
#ifdef __OBJC__
#import <Cocoa/Cocoa.h>
#else
#ifndef FOUNDATION_EXPORT
#if defined(__cplusplus)
#define FOUNDATION_EXPORT extern "C"
#else
#define FOUNDATION_EXPORT extern
#endif
#endif
#endif

#import "sqlite3.h"

FOUNDATION_EXPORT double sqlite3VersionNumber;
FOUNDATION_EXPORT const unsigned char sqlite3VersionString[];

```