### PR TITLE
Add min deployment_target values for Xcode 15

### DIFF
--- a/sqlite3.podspec
+++ b/sqlite3.podspec
@@ -22,6 +22,13 @@ make sqlite3.c sqlite3.h sqlite3ext.h
 CMD
   s.requires_arc = false
 
+  # Setting a deployment_target enables linting of podspecs which depend on sqlite3
+  # Absolute minimum value for a given version of Xcode can be found at https://developer.apple.com/support/xcode/
+  s.ios.deployment_target = '12.0'
+  s.tvos.deployment_target = '12.0'
+  s.macos.deployment_target = '10.13'
+  s.watchos.deployment_target = '4.0'
+
   s.default_subspecs = 'common'
 
   s.subspec 'common' do |ss|


### PR DESCRIPTION
I currently work on a project which is developing a private framework which is dependent on the sqlite3 pod. Thank you for your work in making this podspec available to the public!

Recent versions of Xcode have had trouble validating (linting and publishing) podspecs for frameworks which depend on sqlite3, or any dependency which does not declare a min version/deployment_target. See https://github.com/CocoaPods/CocoaPods/issues/11839 , https://github.com/CocoaPods/CocoaPods/issues/12033 , etc.

This PR sets reasonable defaults for Xcode 15.0.1, based on information available at https://developer.apple.com/support/xcode/ .  I have only validated that it fixes my project's issue for iOS, the other SDKs are included for completeness.

This fixes #22 